### PR TITLE
workaround for an issue where headers are not enriched when using multiple inboundChannelAdapters

### DIFF
--- a/src/main/java/petstore/pubsub/config/IntegrationFlowConfig.java
+++ b/src/main/java/petstore/pubsub/config/IntegrationFlowConfig.java
@@ -1,6 +1,7 @@
 package petstore.pubsub.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -8,6 +9,7 @@ import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.http.dsl.Http;
+import org.springframework.messaging.MessageChannel;
 import petstore.pubsub.service.PetGroupHandler;
 
 @Configuration
@@ -19,8 +21,9 @@ public class IntegrationFlowConfig {
     PetGroupHandler petGroupHandler;
 
     @Bean
-    IntegrationFlow petStoreSubscriptionFlow() {
-        return IntegrationFlow.from("petStoreSubscriptionMessageChannel")
+    IntegrationFlow petStoreSubscriptionFlow(
+            @Qualifier("petStoreSubscriptionMessageChannel") MessageChannel petStoreSubscriptionChannel) {
+        return IntegrationFlow.from(petStoreSubscriptionChannel)
                 .enrichHeaders(spec -> spec.header("petStore.FlowName", "PetStoreIntake"))
                 .handle(petGroupHandler, "handle")
                 .get();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,10 +38,3 @@ spring:
     gcp:
       credentials:
         location: file:./src/main/resources/petstore-project-fake.json
-
-#  datasource:
-#    mydb:
-#      url: jdbc:oracle:thin:@(DESCRIPTION=(ENABLE=BROKEN)(ADDRESS=(PROTOCOL=TCP)(HOST=wcx4-scan.heb.com)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=dmst2_rw.heb.com)))
-#      driver-class-name: oracle.jdbc.OracleDriver
-#      username: ${db.username}
-#      password: ${db.password}


### PR DESCRIPTION
When using 2 inboundChannelAdapter:

1. PubSub: the main inbound adapter
1. Http: the secondary inbound adapter where we can post the same messages via Http/REST Api

and chaining 2 IntegrationFlows, we found that the call to `.enrichHeaders()` in the main IntegrationFlow (using PubSub) did not happen.

More discussion in this StackOverflow [post](https://stackoverflow.com/questions/79248936/spring-integration-dsl-flow-to-another-flow-does-not-execute-enrichedheaders/79249097).